### PR TITLE
feat: add Cloudflare Worker cron job and migrate supabase schema

### DIFF
--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,88 @@
+-- ─────────────────────────────────────────────
+-- SERVANTS
+-- ─────────────────────────────────────────────
+CREATE TABLE public.servants (
+    collection_no     INTEGER PRIMARY KEY,
+    name              TEXT NOT NULL,
+    class_name        TEXT NOT NULL,
+    rarity            SMALLINT NOT NULL,
+    -- NP card type for filtering; null when the servant can choose at runtime
+    np_card           TEXT,
+    np_card_variable  BOOLEAN NOT NULL DEFAULT false,
+    np_card_options   TEXT[],
+    -- attackEnemyOne | attackEnemyAll | support
+    attack_type       TEXT,
+    is_enemy_only     BOOLEAN NOT NULL DEFAULT false,
+    -- null | 'irreversible' | 'reversible'  (ascension-locked kit servants)
+    form_transition   TEXT,
+    -- arbitrary parser annotations consumed by the simulation engine
+    parser_flags      JSONB,
+    aa_data_hash      TEXT,
+    data              JSONB NOT NULL,
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.servants ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public_read" ON public.servants
+    FOR SELECT TO anon USING (true);
+
+CREATE INDEX servants_class_name_idx  ON public.servants (class_name);
+CREATE INDEX servants_rarity_idx      ON public.servants (rarity);
+CREATE INDEX servants_np_card_idx     ON public.servants (np_card);
+CREATE INDEX servants_attack_type_idx ON public.servants (attack_type);
+
+
+-- ─────────────────────────────────────────────
+-- QUESTS
+-- ─────────────────────────────────────────────
+CREATE TABLE public.quests (
+    id            INTEGER PRIMARY KEY,
+    name          TEXT,
+    war_id        INTEGER,
+    war_name      TEXT,
+    recommend_lv  TEXT,
+    consume       SMALLINT,
+    after_clear   TEXT,
+    data          JSONB NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.quests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public_read" ON public.quests
+    FOR SELECT TO anon USING (true);
+
+CREATE INDEX quests_war_id_idx ON public.quests (war_id);
+
+
+-- ─────────────────────────────────────────────
+-- MYSTIC CODES
+-- ─────────────────────────────────────────────
+CREATE TABLE public.mystic_codes (
+    id            INTEGER PRIMARY KEY,
+    name          TEXT,
+    aa_data_hash  TEXT,
+    data          JSONB NOT NULL,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.mystic_codes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public_read" ON public.mystic_codes
+    FOR SELECT TO anon USING (true);
+
+
+-- ─────────────────────────────────────────────
+-- METADATA
+-- ─────────────────────────────────────────────
+CREATE TABLE public.metadata (
+    key        TEXT PRIMARY KEY,
+    value      JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.metadata ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public_read" ON public.metadata
+    FOR SELECT TO anon USING (true);

--- a/supabase/migrations/002_saved_runs.sql
+++ b/supabase/migrations/002_saved_runs.sql
@@ -1,0 +1,55 @@
+-- Saved community farming runs.
+-- Clients submit via supabase.rpc('submit_run', {...}) — never direct INSERT.
+-- Pruning rule: lower total_np_cost wins for the same quest+servants+np_levels key.
+
+CREATE TABLE IF NOT EXISTS public.saved_runs (
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    quest_id               INTEGER NOT NULL,
+    servant_collection_nos INTEGER[] NOT NULL,
+    np_levels              SMALLINT[] NOT NULL,
+    total_np_cost          SMALLINT NOT NULL,
+    token_string           TEXT NOT NULL,
+    wave_results           JSONB NOT NULL DEFAULT '{}',
+    submitted_at           TIMESTAMPTZ DEFAULT now(),
+    CONSTRAINT uq_run_key UNIQUE (quest_id, servant_collection_nos, np_levels)
+);
+
+ALTER TABLE public.saved_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public_read" ON public.saved_runs
+    FOR SELECT TO anon USING (true);
+
+CREATE INDEX saved_runs_quest_id_idx ON public.saved_runs (quest_id);
+CREATE INDEX saved_runs_servants_idx ON public.saved_runs USING GIN (servant_collection_nos);
+CREATE INDEX saved_runs_cost_idx     ON public.saved_runs (total_np_cost);
+
+-- RPC called by browser clients. SECURITY DEFINER bypasses RLS so the
+-- ON CONFLICT ... WHERE pruning clause can execute an UPDATE atomically.
+CREATE OR REPLACE FUNCTION public.submit_run(
+    p_quest_id               INTEGER,
+    p_servant_collection_nos INTEGER[],
+    p_np_levels              SMALLINT[],
+    p_total_np_cost          SMALLINT,
+    p_token_string           TEXT,
+    p_wave_results           JSONB
+) RETURNS void
+  LANGUAGE sql
+  SECURITY DEFINER
+  SET search_path = public
+AS $$
+    INSERT INTO public.saved_runs (
+        quest_id, servant_collection_nos, np_levels,
+        total_np_cost, token_string, wave_results
+    ) VALUES (
+        p_quest_id, p_servant_collection_nos, p_np_levels,
+        p_total_np_cost, p_token_string, p_wave_results
+    )
+    ON CONFLICT ON CONSTRAINT uq_run_key DO UPDATE
+        SET token_string  = EXCLUDED.token_string,
+            wave_results  = EXCLUDED.wave_results,
+            total_np_cost = EXCLUDED.total_np_cost,
+            submitted_at  = now()
+        WHERE EXCLUDED.total_np_cost < saved_runs.total_np_cost;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_run TO anon;

--- a/supabase/migrations/003_face_url_opened_at.sql
+++ b/supabase/migrations/003_face_url_opened_at.sql
@@ -1,0 +1,7 @@
+-- Structured columns added for React client-side data needs.
+-- face_url: max-ascension face image URL extracted from extraAssets JSON, avoids
+--           shipping the full data blob to the browser just for the avatar image.
+-- opened_at: Unix timestamp (seconds) used to sort events newest-first in the UI.
+
+ALTER TABLE public.servants ADD COLUMN IF NOT EXISTS face_url TEXT;
+ALTER TABLE public.quests   ADD COLUMN IF NOT EXISTS opened_at BIGINT;

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fgo-can-it-farm-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --test-scheduled"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0"
+  },
+  "devDependencies": {
+    "wrangler": "^3.28.0"
+  }
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,400 @@
+import { createClient } from '@supabase/supabase-js';
+
+const AA_BASE = 'https://api.atlasacademy.io';
+
+const MASH_COLLECTION_NO     = 2;
+const AOKO_COLLECTION_NO     = 413;
+const MELUSINE_FORM_SKILL_ID = 888550;
+
+const NP_DAMAGE_FUNC_TYPES = new Set([
+  'damageNp',
+  'damageNpPierce',
+  'damageNpIndividual',
+  'damageNpStateIndividualFix',
+  'damageNpIndividualSum',
+]);
+
+const KEEP_WAR_TYPES = new Set(['eventQuest', 'permanent']);
+const RECOMMEND_LVS  = new Set(['90', '90+', '90++', '90★', '90★★']);
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWithBackoff(url, retries = 3) {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        try {
+          return await res.json();
+        } catch (e) {
+          console.error(`JSONDecodeError for ${url}:`, e.message);
+          return null;
+        }
+      }
+      console.error(`HTTP ${res.status} for ${url}`);
+    } catch (e) {
+      console.error(`FetchError for ${url}:`, e.message);
+    }
+    if (attempt < retries - 1) {
+      await sleep(2 ** attempt * 1000);
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Guardrail Parser Pipeline
+// ---------------------------------------------------------------------------
+
+function extractNpCard(data) {
+  const nps = [...(data.noblePhantasms ?? [])].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+  return nps.length > 0 ? (nps[nps.length - 1].card ?? null) : null;
+}
+
+function extractAttackType(data) {
+  const nps = [...(data.noblePhantasms ?? [])].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+  if (nps.length === 0) return 'support';
+  for (const fn of nps[nps.length - 1].functions ?? []) {
+    if (NP_DAMAGE_FUNC_TYPES.has(fn.funcType)) {
+      const t = fn.funcTargetType ?? '';
+      if (t === 'enemy') return 'attackEnemyOne';
+      if (t === 'enemyAll' || t === 'enemyFull') return 'attackEnemyAll';
+    }
+  }
+  return 'support';
+}
+
+function extractFaceUrl(data) {
+  const ascension = data?.extraAssets?.faces?.ascension ?? {};
+  for (const key of ['4', '3', '2', '1']) {
+    if (ascension[key]) return ascension[key];
+  }
+  const vals = Object.values(ascension);
+  return vals.length > 0 ? vals[0] : null;
+}
+
+/**
+ * 5-step pre-parse of raw Atlas Academy servant JSON.
+ * Returns a dict of structured column values for public.servants.
+ */
+function runGuardrailPipeline(data) {
+  const collectionNo = data.collectionNo;
+  const nps = [...(data.noblePhantasms ?? [])].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
+  const npCardSet = new Set(nps.map(np => np.card).filter(Boolean));
+  const npCards   = [...npCardSet].sort();
+  const variable  = npCards.length > 1;
+
+  const result = {
+    np_card:          variable ? null : extractNpCard(data),
+    np_card_variable: variable,
+    np_card_options:  variable ? npCards : null,
+    attack_type:      extractAttackType(data),
+    is_enemy_only:    data.isEnemy ?? false,
+    form_transition:  null,
+    parser_flags:     {},
+    face_url:         extractFaceUrl(data),
+  };
+
+  // Step 1 — transformServant skills (Jekyll-style one-way transform)
+  const transformSkills = (data.skills ?? []).filter(s =>
+    (s.functions ?? []).some(f => f.funcType === 'transformServant')
+  );
+  if (transformSkills.length === 1) {
+    result.form_transition = 'irreversible';
+    result.parser_flags.has_transform_servant = true;
+  } else if (transformSkills.length > 1) {
+    result.form_transition = 'reversible';
+    result.parser_flags.has_transform_servant = true;
+  }
+
+  // Step 2 — costumeAdd: Mash hard-coded to Ortinax (most upgraded form)
+  if (collectionNo === MASH_COLLECTION_NO) {
+    result.parser_flags.mash_ortinax = true;
+  }
+
+  // Step 3 — formIdx: Melusine's form-change skill ID → override to irreversible
+  for (const skill of data.skills ?? []) {
+    if (skill.id === MELUSINE_FORM_SKILL_ID) {
+      result.form_transition = 'irreversible';
+      result.parser_flags.melusine_form_skill = true;
+    }
+  }
+
+  // Step 4 — condLimitCount: record ascension-gated skill IDs for the sim engine
+  const gated = (data.skills ?? [])
+    .filter(s => (s.condLimitCount ?? 0) > 0)
+    .map(s => s.id);
+  if (gated.length > 0) {
+    result.parser_flags.ascension_gated_skill_ids = gated;
+  }
+
+  // Step 5 — modal NP card choice (Space Ishtar, Emiya etc.)
+  if (variable) {
+    result.parser_flags.requires_choice = true;
+  }
+
+  // Aoko: BattleEngine needs to know to apply post-NP transform
+  if (collectionNo === AOKO_COLLECTION_NO) {
+    result.parser_flags.is_aoko = true;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Servants
+// ---------------------------------------------------------------------------
+
+async function upsertServant(supabase, data, aaHash) {
+  const parsed = runGuardrailPipeline(data);
+  const { error } = await supabase.from('servants').upsert({
+    collection_no:    data.collectionNo,
+    name:             data.name ?? '',
+    class_name:       data.className ?? '',
+    rarity:           data.rarity ?? 0,
+    np_card:          parsed.np_card,
+    np_card_variable: parsed.np_card_variable,
+    np_card_options:  parsed.np_card_options,
+    attack_type:      parsed.attack_type,
+    is_enemy_only:    parsed.is_enemy_only,
+    form_transition:  parsed.form_transition,
+    parser_flags:     parsed.parser_flags,
+    face_url:         parsed.face_url,
+    aa_data_hash:     aaHash,
+    data,
+    updated_at:       new Date().toISOString(),
+  }, { onConflict: 'collection_no' });
+  if (error) throw new Error(`Upsert servant ${data.collectionNo}: ${error.message}`);
+}
+
+async function retrieveServants(supabase) {
+  const basicList = await fetchWithBackoff(`${AA_BASE}/export/JP/basic_servant.json`);
+  if (!basicList) {
+    console.error('Failed to fetch basic_servant.json');
+    return { checked: 0, updated: 0 };
+  }
+
+  let checked = 0;
+  let updated = 0;
+
+  for (const entry of basicList) {
+    const collectionNo = entry.collectionNo;
+    const aaHash       = entry.hash ?? '';
+    if (!collectionNo) continue;
+    checked++;
+
+    const { data: existing } = await supabase
+      .from('servants')
+      .select('aa_data_hash')
+      .eq('collection_no', collectionNo)
+      .maybeSingle();
+
+    if (existing?.aa_data_hash === aaHash) {
+      console.log(`Servant ${collectionNo}: hash unchanged, skipping`);
+      continue;
+    }
+
+    const data = await fetchWithBackoff(
+      `${AA_BASE}/nice/JP/servant/${collectionNo}?lore=true&expand=true&lang=en`
+    );
+    if (!data) {
+      console.error(`Failed to fetch servant ${collectionNo}`);
+      await sleep(500);
+      continue;
+    }
+
+    await upsertServant(supabase, data, aaHash);
+    updated++;
+    console.log(`Upserted servant ${collectionNo}`);
+    await sleep(500);
+  }
+
+  return { checked, updated };
+}
+
+// ---------------------------------------------------------------------------
+// Quests
+// ---------------------------------------------------------------------------
+
+async function upsertQuest(supabase, data, warId, warName) {
+  const questId = data.id;
+  const stages  = data.stages ?? [];
+  if (!questId || stages.length === 0 || !stages[0].enemies) {
+    console.error(`Quest ${questId}: missing id or empty enemies`);
+    return;
+  }
+  const { error } = await supabase.from('quests').upsert({
+    id:           questId,
+    name:         data.name ?? '',
+    war_id:       warId,
+    war_name:     warName,
+    recommend_lv: data.recommendLv ?? '',
+    consume:      data.consume ?? 0,
+    after_clear:  data.afterClear ?? '',
+    opened_at:    data.openedAt,
+    data,
+    updated_at:   new Date().toISOString(),
+  }, { onConflict: 'id' });
+  if (error) throw new Error(`Upsert quest ${questId}: ${error.message}`);
+  console.log(`Upserted quest ${questId}`);
+}
+
+async function retrieveQuests(supabase) {
+  const basicWars = await fetchWithBackoff(`${AA_BASE}/export/JP/basic_war.json`);
+  if (!basicWars) {
+    console.error('Failed to fetch basic_war.json');
+    return 0;
+  }
+
+  const warIds = basicWars.filter(w => KEEP_WAR_TYPES.has(w.type)).map(w => w.id);
+  console.log(`Processing ${warIds.length} wars`);
+
+  const queue = [];
+  for (const warId of warIds) {
+    const warData = await fetchWithBackoff(`${AA_BASE}/nice/JP/war/${warId}?lang=en`);
+    if (!warData) {
+      console.error(`Failed to fetch war ${warId}`);
+      await sleep(300);
+      continue;
+    }
+    const warName = warData.longName || warData.name || '';
+    for (const spot of warData.spots ?? []) {
+      for (const quest of spot.quests ?? []) {
+        if (
+          RECOMMEND_LVS.has(quest.recommendLv) &&
+          quest.consume === 40 &&
+          quest.afterClear === 'repeatLast'
+        ) {
+          queue.push([quest.id, warId, warName]);
+        }
+      }
+    }
+    await sleep(300);
+  }
+
+  console.log(`Found ${queue.length} qualifying quests`);
+
+  let updated = 0;
+  for (const [questId, warId, warName] of queue) {
+    const data = await fetchWithBackoff(`${AA_BASE}/nice/JP/quest/${questId}/1?lang=en`);
+    if (!data) {
+      console.error(`Failed to fetch quest ${questId}`);
+      await sleep(300);
+      continue;
+    }
+    await upsertQuest(supabase, data, warId, warName);
+    updated++;
+    await sleep(300);
+  }
+
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Mystic Codes
+// ---------------------------------------------------------------------------
+
+async function retrieveMysticCodes(supabase) {
+  const basicList = await fetchWithBackoff(`${AA_BASE}/export/JP/basic_mystic_code.json`);
+  if (!basicList) {
+    console.error('Failed to fetch basic_mystic_code.json');
+    return 0;
+  }
+
+  let updated = 0;
+  for (const entry of basicList) {
+    const mcId   = entry.id;
+    const aaHash = entry.hash ?? '';
+    if (!mcId) continue;
+
+    const { data: existing } = await supabase
+      .from('mystic_codes')
+      .select('aa_data_hash')
+      .eq('id', mcId)
+      .maybeSingle();
+
+    if (existing?.aa_data_hash === aaHash) {
+      console.log(`Mystic code ${mcId}: hash unchanged, skipping`);
+      continue;
+    }
+
+    const data = await fetchWithBackoff(`${AA_BASE}/nice/JP/MC/${mcId}?lang=en`);
+    if (!data) {
+      console.error(`Failed to fetch mystic code ${mcId}`);
+      await sleep(300);
+      continue;
+    }
+
+    const { error } = await supabase.from('mystic_codes').upsert({
+      id:           mcId,
+      name:         data.name ?? '',
+      aa_data_hash: aaHash,
+      data,
+      updated_at:   new Date().toISOString(),
+    }, { onConflict: 'id' });
+    if (error) throw new Error(`Upsert mystic code ${mcId}: ${error.message}`);
+    updated++;
+    console.log(`Upserted mystic code ${mcId}`);
+    await sleep(300);
+  }
+
+  return updated;
+}
+
+// ---------------------------------------------------------------------------
+// Metadata / version
+// ---------------------------------------------------------------------------
+
+async function updateJpHash(supabase) {
+  const info = await fetchWithBackoff(`${AA_BASE}/info`);
+  if (!info) {
+    console.error('Failed to fetch /info');
+    return '';
+  }
+  const jpHash = info?.JP?.hash ?? '';
+  const { error } = await supabase.from('metadata').upsert({
+    key:        'aa_version',
+    value:      { jp_hash: jpHash, updated_at: new Date().toISOString() },
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'key' });
+  if (error) throw new Error(`Update JP hash: ${error.message}`);
+  console.log(`Stored JP hash: ${jpHash}`);
+  return jpHash;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export default {
+  async scheduled(event, env, ctx) {
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+      auth: { persistSession: false },
+    });
+
+    const start = Date.now();
+    console.log('=== Starting update run ===');
+
+    const newJpHash                          = await updateJpHash(supabase);
+    const { checked: servantsChecked,
+            updated: servantsUpdated }        = await retrieveServants(supabase);
+    const questsUpdated                      = await retrieveQuests(supabase);
+    const mcUpdated                          = await retrieveMysticCodes(supabase);
+
+    const summary = {
+      servants_checked:    servantsChecked,
+      servants_updated:    servantsUpdated,
+      quests_updated:      questsUpdated,
+      mystic_codes_updated: mcUpdated,
+      new_jp_hash:         newJpHash,
+      duration_seconds:    +((Date.now() - start) / 1000).toFixed(2),
+    };
+    console.log('Update complete:', JSON.stringify(summary));
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,10 @@
+name = "fgo-can-it-farm-worker"
+main = "src/index.js"
+compatibility_date = "2024-09-23"
+
+# Secrets (set via `wrangler secret put`):
+#   SUPABASE_URL
+#   SUPABASE_SERVICE_ROLE_KEY
+
+[triggers]
+crons = ["0 0 * * *"]


### PR DESCRIPTION
- worker/src/index.js: JS rewrite of GetUpdatesAndUpsert.py as a Cloudflare Worker scheduled handler. Faithfully reproduces the guardrail pipeline (np_card, attack_type, face_url, form_transition, parser_flags), hash-diff logic against Supabase, and upsert structure for servants, quests, mystic codes, and metadata.
- worker/wrangler.toml: daily cron trigger (0 0 * * *), uses SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY as Worker secrets.
- worker/package.json: @supabase/supabase-js + wrangler dev deps.
- supabase/migrations/: moved from fgo-can-it-farm repo (001, 002, 003).