### PR TITLE
FR-9: harden round-trip + verify-deploy docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,12 @@ lookups. Caveat: MCP results flow into the model's context, so don't pull large
 `data` blobs (servants/quests) through it — `curl` PostgREST to a file, or rely
 on the trimmed rows.
 
+Schema changes live in `supabase/migrations/` (applied by hand in numeric order —
+see `supabase/README.md`). The DB is **not** CLI-linked, so a committed migration
+is not necessarily deployed; verify with the SQL checks in that README before
+assuming a table/RPC exists. FR-9 run submission + bug reports require migration
+`004`.
+
 ## Data Blob Trimming (sync pipeline)
 
 `shared/atlasSync.js` trims each `data` blob before upsert so the engine gets

--- a/src/App.js
+++ b/src/App.js
@@ -241,7 +241,17 @@ const App = () => {
       p_mystic_code_id,
     });
 
-    if (error) return { success: false, error: error.message };
+    if (error) {
+      // The 7-arg submit_run lives in Supabase migration 004. If only 002 is
+      // deployed, PostgREST can't find the overload (PGRST202 / "function ...
+      // does not exist") — surface the actual fix instead of the raw error.
+      const missingFn = error.code === 'PGRST202' ||
+        /function .*submit_run.* does not exist/i.test(error.message || '');
+      if (missingFn) {
+        return { success: false, error: 'Run submission needs Supabase migration 004 (see supabase/README.md).' };
+      }
+      return { success: false, error: error.message };
+    }
     return { success: true };
   };
 

--- a/src/simulation/__tests__/fr9Roundtrip.test.js
+++ b/src/simulation/__tests__/fr9Roundtrip.test.js
@@ -1,0 +1,89 @@
+/**
+ * FR-9 round-trip: a re-simulation of the same inputs must reconcile as a MATCH
+ * against the stored summary, and genuine drift must be caught. Exercises the
+ * deterministic core the saved-run feature relies on (summarizeEngine →
+ * reconcileWaveResults) against REAL engine output — the DB reconstruction in
+ * resimulateSavedRun is verified separately against the live database.
+ *
+ * Acceptance (spec §7): "Saved run stores token+summary; re-sim reproduces it;
+ * divergence offers a bug report."
+ */
+import { Driver } from '../Driver';
+import { buildSimInputs } from '../__fixtures__/realData';
+import { summarizeEngine, reconcileWaveResults } from '../RunAdapter';
+
+// paladin_mash full clear (same inputs as summarizeEngine.test.js): 3 waves,
+// per_enemy populated, deterministic.
+const TEAM = [
+  { collectionNo: 1,   opts: { np: 3, initialCharge: 50, attack: 2000 } },
+  { collectionNo: 16,  opts: { np: 5, initialCharge: 20, attack: 2400, npUp: 0.80 } },
+  { collectionNo: 150, opts: {} },
+  { collectionNo: 316, opts: {} },
+  { collectionNo: 314, opts: {} },
+];
+const QUEST_ID = 94095710;
+const MC_ID = 210;
+const TOKENS = 'a b1 f g h i1 4 5 # x31 d e1 g1 i1 4 # b f1 j 4 #';
+
+const summarize = () => {
+  const inputs = buildSimInputs({ servants: TEAM, questId: QUEST_ID, mysticCodeId: MC_ID });
+  return summarizeEngine(new Driver(inputs).run(TOKENS));
+};
+
+// Engine wave keys are numeric strings ("1","2","3"); the spec doc's "wave1" is
+// illustrative. Resolve the first wave key dynamically.
+const firstWaveKey = (waves) => Object.keys(waves)[0];
+
+describe('FR-9 round-trip — re-sim reproduces the stored summary', () => {
+  test('a re-sim of identical inputs reconciles as a match (no false divergence)', () => {
+    const stored = summarize();
+    const fresh = summarize();
+    const waves = stored.stats.waves;
+
+    // Sanity: a real multi-wave clear with FR-8 per_enemy data on the path.
+    expect(stored.quest_cleared).toBe(true);
+    expect(Object.keys(waves).length).toBeGreaterThan(1);
+    expect(waves[firstWaveKey(waves)].per_enemy.length).toBeGreaterThan(0);
+
+    const { diverged, diffs } = reconcileWaveResults(waves, fresh.stats.waves);
+    expect(diffs).toEqual({});
+    expect(diverged).toBe(false);
+  });
+});
+
+describe('FR-9 round-trip — drift is caught on real summary shape', () => {
+  const clone = (o) => JSON.parse(JSON.stringify(o));
+
+  test('a damage drop past tolerance diverges on damage_at_10', () => {
+    const stored = summarize().stats.waves;
+    const w = firstWaveKey(stored);
+    const fresh = clone(stored);
+    fresh[w].damage_at_10 *= 0.5; // -50%, well past the 1% tolerance
+
+    const { diverged, diffs } = reconcileWaveResults(stored, fresh);
+    expect(diverged).toBe(true);
+    expect(diffs[w].field).toBe('damage_at_10');
+  });
+
+  test('a flipped outcome diverges on outcome', () => {
+    const stored = summarize().stats.waves;
+    const w = firstWaveKey(stored);
+    const fresh = clone(stored);
+    fresh[w].outcome = fresh[w].outcome === 'guaranteed' ? 'impossible' : 'guaranteed';
+
+    const { diverged, diffs } = reconcileWaveResults(stored, fresh);
+    expect(diverged).toBe(true);
+    expect(diffs[w].field).toBe('outcome');
+  });
+
+  test('a per-enemy damage drift diverges on that enemy (FR-8 granular)', () => {
+    const stored = summarize().stats.waves;
+    const w = firstWaveKey(stored);
+    const fresh = clone(stored);
+    fresh[w].per_enemy[0].damage_taken *= 0.5;
+
+    const { diverged, diffs } = reconcileWaveResults(stored, fresh);
+    expect(diverged).toBe(true);
+    expect(diffs[w].field).toBe('per_enemy[0].damage_taken');
+  });
+});

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,50 @@
+# Supabase migrations
+
+SQL migrations for the FGO-can-it-farm database, applied **in numeric order**.
+
+| File | Adds |
+|---|---|
+| `migrations/001_initial_schema.sql` | `servants`, `quests`, `mystic_codes`, `metadata` + anon read RLS |
+| `migrations/002_saved_runs.sql` | `saved_runs` table + 6-arg `submit_run` RPC |
+| `migrations/003_face_url_opened_at.sql` | `servants.face_url`, `quests.opened_at` |
+| `migrations/004_fr9_run_reports.sql` | **FR-9:** `saved_runs.mystic_code_id`, 7-arg `submit_run`, `run_reports` table, `submit_run_report` RPC |
+
+## How to apply
+
+This project has no `supabase/config.toml` and is not CLI-linked, so migrations
+are run **by hand in the Supabase SQL editor**: open each file in order and run
+it against the project. (If you later `supabase link` the project,
+`supabase db push` will apply them instead.)
+
+> **Ordering matters for 004.** `004` does `DROP FUNCTION` on the 6-arg
+> `submit_run` from `002` and recreates it with a 7th `p_mystic_code_id`
+> parameter. Apply `002` before `004`.
+
+## FR-9 deployment is required
+
+The app's run-submission and community-bug-report features depend on `004`:
+
+- `src/App.js` `handleSubmitRun` calls the **7-arg** `submit_run` (with
+  `p_mystic_code_id`). If only `002` is deployed, every run submission fails with
+  a "function does not exist" error.
+- `src/components/SearchPage.js` "Report discrepancy" calls `submit_run_report`
+  and writes to `run_reports`.
+
+### Verify it's live
+
+Run these read-only checks in the SQL editor:
+
+```sql
+-- 7-arg submit_run present? (expect a row with pronargs = 7)
+SELECT proname, pronargs FROM pg_proc WHERE proname = 'submit_run';
+
+-- report RPC present?
+SELECT proname FROM pg_proc WHERE proname = 'submit_run_report';
+
+-- table + column present?
+SELECT to_regclass('public.run_reports');
+SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'saved_runs' AND column_name = 'mystic_code_id';
+```
+
+If any object is missing, run `migrations/004_fr9_run_reports.sql`.


### PR DESCRIPTION
## Summary

"Begin FR-9" turned out to be a finishing task — **FR-9 was already implemented and merged** (`ab3c62d`): migration `004` (`run_reports`, `submit_run_report`, `mystic_code_id`, 7-arg `submit_run`), the SearchPage Verify+Report UI, and the RunAdapter re-sim/reconcile helpers. This PR closes the two real gaps: test hardening and deploy de-risking.

## Changes

- **`fr9Roundtrip.test.js`** (new) — guards the §7 acceptance ("re-sim reproduces it") against **real engine output**: a re-sim of identical inputs reconciles as a match (no false divergence), and damage / outcome / per-enemy drift is caught. Uses the existing DB-free `buildSimInputs` + `summarizeEngine` pattern.
- **`supabase/README.md`** (new) — there was no doc on how migrations are applied. Documents numeric-order hand-application, the `002 → 004` ordering dependency (004 drops/recreates `submit_run`), that **004 is required** for run submission + bug reports, and read-only SQL to verify it's live.
- **`CLAUDE.md`** — note that a committed migration isn't necessarily deployed; verify before assuming a table/RPC exists.
- **`App.js`** — when the 7-arg `submit_run` overload is missing (`PGRST202`), return a clear "needs Supabase migration 004" message instead of the raw PostgREST error, so the deployment gap is self-diagnosing.

## Deploy verification (action for owner)

I can't reach the live DB from here. **If migration `004` isn't deployed, run submission is currently broken** (the app calls the 7-arg `submit_run`). Please run the SQL checks in `supabase/README.md` and apply `004` if any object is missing.

## Verification

`CI=true npx react-scripts test --watchAll=false` → 20 suites / 147 tests green, including the new round-trip suite; existing snapshots unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)