### PR TITLE
Command-input UI overhaul: drop redundant top builder, group palette,…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -343,6 +343,7 @@ const App = () => {
         team={team}
         servants={servants}
         selectedMysticCode={selectedMysticCode}
+        setSelectedMysticCode={setSelectedMysticCode}
         selectedQuest={selectedQuest}
         servantEffects={servantEffects}
         updateServantEffects={updateServantEffects}

--- a/src/CombatDashboard.css
+++ b/src/CombatDashboard.css
@@ -78,9 +78,28 @@
 .cd-pip--ready { background: var(--color-gold-dim); color: var(--color-gold); }
 
 /* Palette */
-.dash__palette { display: flex; flex-wrap: wrap; gap: var(--spacing-xs); }
+.dash__palette { display: flex; flex-direction: column; gap: var(--spacing-sm); }
+.dash__pgroup {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 6px 8px; border-radius: 8px;
+  background: var(--color-surface-2); border: 1px solid var(--color-border);
+}
+.dash__pgroup-label {
+  font-size: 0.62rem; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--color-text-dim);
+}
+.dash__pgroup-btns { display: flex; flex-wrap: wrap; gap: var(--spacing-xs); }
 .palette-btn { text-transform: none; }
 .palette-btn--np { border-color: var(--color-gold); }
+
+/* Net stat totals (config + live buffs) */
+.ally__stats { display: flex; flex-wrap: wrap; gap: 2px; margin-top: 4px; }
+.stat-pill {
+  font-size: 0.6rem; line-height: 1.3; padding: 0 4px; border-radius: 3px;
+  background: var(--color-gold-dim);
+  border: 1px solid color-mix(in srgb, var(--color-gold) 30%, transparent);
+  color: var(--color-text); white-space: nowrap; font-variant-numeric: tabular-nums;
+}
 
 /* Chips */
 .dash__chips { display: flex; flex-wrap: wrap; gap: var(--spacing-xs); min-height: 32px; }

--- a/src/components/CombatDashboard.js
+++ b/src/components/CombatDashboard.js
@@ -48,6 +48,29 @@ const Buffs = ({ buffs }) => {
   );
 };
 
+/** Net stat totals (config effects + live buffs) for a frontline servant.
+ *  Renders only the stats that differ from their neutral baseline. */
+const StatTotals = ({ stats }) => {
+  if (!stats) return null;
+  const pct = (v) => `${v > 0 ? '+' : ''}${Math.round(v * 100)}%`;
+  const items = [
+    ['ATK', stats.atkUp], ['Buster', stats.busterUp], ['Arts', stats.artsUp], ['Quick', stats.quickUp],
+    ['B.DMG', stats.busterDmgUp], ['A.DMG', stats.artsDmgUp], ['Q.DMG', stats.quickDmgUp],
+    ['NP DMG', stats.npDmgUp], ['NP Gen', stats.npGen],
+  ].filter(([, v]) => Math.abs(v || 0) >= 0.005);
+  if (stats.oc > 1) items.push(['OC', stats.oc]);
+  if (!items.length) return null;
+  return (
+    <div className="ally__stats">
+      {items.map(([label, v]) => (
+        <span key={label} className="stat-pill" title={`${label} net total`}>
+          {label} {label === 'OC' ? `×${v}` : pct(v)}
+        </span>
+      ))}
+    </div>
+  );
+};
+
 /**
  * FR-7 in-combat dashboard + step-through scrubber. Enemies left, frontline
  * allies right, palette + command chips middle. A cursor lets you view the live
@@ -152,6 +175,26 @@ const CombatDashboard = ({ team, selectedQuest, selectedMysticCode, servantEffec
   // Currently-fireable frontline NPs — previewed in every enemy box.
   const readyNps = options.filter((o) => o.kind === 'np' && o.available);
 
+  // FR-3 palette, grouped for legibility: one section per occupied front slot
+  // (that servant's skills, then its NP), then Mystic Code, Swaps, End Turn.
+  const actionGroups = [];
+  [0, 1, 2].forEach((slot) => {
+    const s = snapshot.front[slot];
+    const opts = options.filter(
+      (o) => (o.kind === 'skill' || o.kind === 'np') && o.servantSlot === slot,
+    );
+    if (!opts.length) return;
+    // Skills first, NP last.
+    opts.sort((a, b) => (a.kind === b.kind ? 0 : a.kind === 'np' ? 1 : -1));
+    actionGroups.push({ key: `s${slot}`, label: `S${slot + 1} · ${s?.name || 'Servant'}`, options: opts });
+  });
+  const mcOpts = options.filter((o) => o.kind === 'mc');
+  if (mcOpts.length) actionGroups.push({ key: 'mc', label: 'Mystic Code', options: mcOpts });
+  const swapOpts = options.filter((o) => o.kind === 'swap');
+  if (swapOpts.length) actionGroups.push({ key: 'swap', label: 'Swaps', options: swapOpts });
+  const endOpts = options.filter((o) => o.kind === 'endTurn');
+  if (endOpts.length) actionGroups.push({ key: 'end', label: 'End Turn', options: endOpts });
+
   return (
     <Box className="dash">
       <Box className="dash__header">
@@ -223,20 +266,27 @@ const CombatDashboard = ({ team, selectedQuest, selectedMysticCode, servantEffec
             Actions {atEnd ? '' : `(branch from step ${step})`}
           </Typography>
           <Box className="dash__palette">
-            {options.map((opt) => (
-              <Tooltip key={opt.token}
-                title={opt.available ? humanizeToken(resolveToken(opt, {}), engine) : (opt.reason || 'unavailable')}
-                arrow>
-                <span>
-                  <Button size="small"
-                    variant={pending?.option?.token === opt.token ? 'contained' : 'outlined'}
-                    disabled={!opt.available}
-                    className={`palette-btn palette-btn--${opt.kind} palette-btn--${opt.targetClass}`}
-                    onClick={() => onOption(opt)}>
-                    {opt.label}{!opt.available && opt.reason ? ` (${opt.reason})` : ''}
-                  </Button>
-                </span>
-              </Tooltip>
+            {actionGroups.map((g) => (
+              <Box key={g.key} className="dash__pgroup">
+                <span className="dash__pgroup-label">{g.label}</span>
+                <Box className="dash__pgroup-btns">
+                  {g.options.map((opt) => (
+                    <Tooltip key={opt.token}
+                      title={opt.available ? humanizeToken(resolveToken(opt, {}), engine) : (opt.reason || 'unavailable')}
+                      arrow>
+                      <span>
+                        <Button size="small"
+                          variant={pending?.option?.token === opt.token ? 'contained' : 'outlined'}
+                          disabled={!opt.available}
+                          className={`palette-btn palette-btn--${opt.kind} palette-btn--${opt.targetClass}`}
+                          onClick={() => onOption(opt)}>
+                          {opt.label}{!opt.available && opt.reason ? ` (${opt.reason})` : ''}
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  ))}
+                </Box>
+              </Box>
             ))}
           </Box>
 
@@ -290,6 +340,7 @@ const CombatDashboard = ({ team, selectedQuest, selectedMysticCode, servantEffec
                       <span key={k} className={`cd-pip ${cd === 0 ? 'cd-pip--ready' : ''}`}>{cd === 0 ? '✓' : cd}</span>
                     ))}
                   </div>
+                  <StatTotals stats={s.stats} />
                   <Buffs buffs={s.buffs} />
                 </>
               ) : <span className="ally__slot-empty">Empty</span>}

--- a/src/components/CommandInputPage.js
+++ b/src/components/CommandInputPage.js
@@ -2,18 +2,15 @@ import React from 'react';
 import { Button, Typography, Box, Container, Modal, Chip, CircularProgress, Alert } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import '../CommandInputPage.css';
-import SourceTargetCommandInput from './SourceTargetCommandInput';
 import CombatDashboard from './CombatDashboard';
 import SimulationStats from './SimulationStats';
-import { supabase } from '../supabaseClient';
-import { parseServantSkills } from './skillInfo';
 import CommandChips from './CommandChips';
 import { prepareSimInputs } from '../simulation/RunAdapter';
 import { buildEngineAt } from '../simulation/CommandState';
 
 const CommandInputPage = ({
-  team, servants, setTeam, activeServant, setActiveServant,
-  commands, setCommands, selectedQuest, selectedMysticCode, setSelectedMysticCode,
+  team, servants,
+  commands, setCommands, selectedQuest, selectedMysticCode,
   servantEffects,
   handleSubmit, openModal, handleOpenModal, handleCloseModal,
   simulationResult, setSimulationResult,
@@ -23,26 +20,10 @@ const CommandInputPage = ({
   const [commandsHistory, setCommandsHistory] = React.useState([]);
   const [submitStatus, setSubmitStatus] = React.useState(null);
   const [submitError, setSubmitError] = React.useState('');
-  const [skillInfo, setSkillInfo] = React.useState({}); // collectionNo -> parsed skills
   const [simInputs, setSimInputs] = React.useState(null); // engine-replay validation source
 
-  // Fetch full data for the current team so the builder can label skills and
-  // know which need an ally target. Keyed by the team's collection numbers.
+  // Keyed by the team's collection numbers — drives the simInputs rebuild below.
   const teamKey = team.map(s => s.collectionNo || '').join(',');
-  React.useEffect(() => {
-    const ids = team.map(s => s.collectionNo).filter(Boolean).map(Number);
-    if (ids.length === 0) { setSkillInfo({}); return; }
-    let cancelled = false;
-    (async () => {
-      const { data, error } = await supabase.from('servants').select('collection_no, data').in('collection_no', ids);
-      if (error || cancelled) return;
-      const map = {};
-      for (const row of data || []) map[String(row.collection_no)] = parseServantSkills(row.data);
-      if (!cancelled) setSkillInfo(map);
-    })();
-    return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamKey]);
 
   React.useEffect(() => {
     setSubmitStatus(null);
@@ -88,13 +69,6 @@ const CommandInputPage = ({
 
   const filledCount = team.filter(s => s.collectionNo).length;
   const canRun = commands.length > 0 && !!selectedQuest && filledCount > 0;
-
-  const addCommand = (command) => {
-    setCommands(prev => {
-      setCommandsHistory(h => [...h, prev]);
-      return [...prev, command];
-    });
-  };
 
   const setCommandsWithHistory = (newCommands) => {
     setCommands(prev => {
@@ -148,19 +122,6 @@ const CommandInputPage = ({
 
   return (
     <Container className="command-input-container" disableGutters maxWidth={false} style={{ marginRight: 'var(--team-panel-width)' }}>
-      <SourceTargetCommandInput
-        team={team}
-        servants={servants}
-        setTeam={setTeam}
-        selectedMysticCode={selectedMysticCode}
-        setSelectedMysticCode={setSelectedMysticCode}
-        addCommand={addCommand}
-        updateCommands={setCommands}
-        selectedSlot={activeServant}
-        setSelectedSlot={setActiveServant}
-        skillInfo={skillInfo}
-      />
-
       <CombatDashboard
         team={team}
         selectedQuest={selectedQuest}

--- a/src/components/StickyTeamBar.js
+++ b/src/components/StickyTeamBar.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Box, Button, Typography, TextField, Checkbox, InputAdornment } from '@mui/material';
+import { Box, Button, Typography, TextField, Checkbox, InputAdornment, Select, MenuItem } from '@mui/material';
 import ServantAvatar from './ServantAvatar';
 import '../ui-vars.css';
 import '../team-sticky.css';
@@ -36,6 +36,7 @@ const StickyTeamBar = ({
   team = [],
   servants = [],
   selectedMysticCode,
+  setSelectedMysticCode = () => {},
   selectedQuest,
   servantEffects = [],
   updateServantEffects = () => {},
@@ -178,9 +179,22 @@ const StickyTeamBar = ({
       </div>
 
       <div className="team-panel-info">
-        <Typography variant="caption" sx={{ display: 'block', color: 'var(--color-text-dim)' }}>
-          MC: {selectedMysticCode ? (MYSTIC_CODE_NAMES[selectedMysticCode] || `ID ${selectedMysticCode}`) : 'None'}
+        <Typography variant="caption" sx={{ display: 'block', color: 'var(--color-text-dim)', mb: 0.25 }}>
+          Mystic Code
         </Typography>
+        <Select
+          value={selectedMysticCode ?? ''}
+          onChange={(e) => setSelectedMysticCode(e.target.value === '' ? null : e.target.value)}
+          displayEmpty
+          fullWidth
+          size="small"
+          sx={{ mb: 1, fontSize: '0.78rem' }}
+        >
+          <MenuItem value=""><em>None</em></MenuItem>
+          {Object.entries(MYSTIC_CODE_NAMES).map(([id, name]) => (
+            <MenuItem key={id} value={Number(id)} sx={{ fontSize: '0.78rem' }}>{name}</MenuItem>
+          ))}
+        </Select>
         <Typography variant="caption" sx={{ display: 'block', color: 'var(--color-text-dim)' }} noWrap>
           Quest: {selectedQuest?.name || 'None'}
         </Typography>

--- a/src/simulation/CommandState.js
+++ b/src/simulation/CommandState.js
@@ -296,12 +296,32 @@ export function legalNextTokens(engine) {
 
 function servantSnapshot(servant, slot) {
   if (!servant) return null;
+  // Net stat totals: fold configured effects (seeded into user* fields) + live
+  // buffs into the servant's derived mods. Idempotent recompute on the throwaway
+  // replay engine; guarded so fixture stubs without a full Buffs don't throw.
+  let stats = null;
+  try {
+    servant.buffs?.processServantBuffs?.();
+    stats = {
+      atkUp: servant.atkMod ?? 0,
+      busterUp: servant.bUp ?? 0,
+      artsUp: servant.aUp ?? 0,
+      quickUp: servant.qUp ?? 0,
+      busterDmgUp: servant.busterCardDamageUp ?? 0,
+      artsDmgUp: servant.artsCardDamageUp ?? 0,
+      quickDmgUp: servant.quickCardDamageUp ?? 0,
+      npDmgUp: servant.npDamageMod ?? 0,
+      npGen: (servant.npGainMod ?? 1) - 1,
+      oc: servant.ocLevel ?? 1,
+    };
+  } catch { stats = null; }
   return {
     slot,
     collectionNo: servant.id,
     name: servant.name,
     faceUrl: servant.data?.face_url ?? null,
     npGauge: Math.round(servant.npGauge * 10) / 10,
+    stats,
     cooldowns: [servant.skills.cooldowns[1], servant.skills.cooldowns[2], servant.skills.cooldowns[3]],
     maxCooldowns: [servant.skills.maxCooldowns[1], servant.skills.maxCooldowns[2], servant.skills.maxCooldowns[3]],
     // Active buffs for the step-through view (name · value · turns; -1 turns = permanent).


### PR DESCRIPTION
… net stat totals, MC in team panel

- Remove SourceTargetCommandInput from the page; CombatDashboard is the sole command builder (deletes its dead skillInfo fetch + unused props)
- Group the dashboard Actions palette into labeled sections: per-servant (skills + NP), Mystic Code, Swaps, End Turn
- Add per-ally net stat totals (config effects + live buffs) via a guarded processServantBuffs recompute in servantSnapshot; render compact stat chips alongside the existing live buff pills
- Move Mystic Code selection into the right-hand Team panel as a compact dropdown; remove the wide MC block